### PR TITLE
Add `wasm-ld` toolchain implementation

### DIFF
--- a/proposals/custom-page-sizes/Overview.md
+++ b/proposals/custom-page-sizes/Overview.md
@@ -419,7 +419,7 @@ Engines:
 Toolchains:
 
 * [ ] [Binaryen and `wasm-opt`](https://github.com/WebAssembly/binaryen/issues/6873)
-* [ ] `wasm-ld` in LLVM
+* [x] [`wasm-ld` in LLVM](https://github.com/llvm/llvm-project/pull/128942)
 * [x] [The Virgil language toolchain](https://github.com/titzer/virgil/pull/272)
 
 Binary decoders:


### PR DESCRIPTION
Support for custom page sizes [was added](https://github.com/llvm/llvm-project/pull/128942) via the `--page-size=N` CLI flag in `wasm-ld`.

Additionally, `wasm-ld` defines a `__wasm_first_page_end` symbol, whose address is the end of the first page, a.k.a. the start of the second page, a.k.a. is the Wasm page size. This allows source files to be written in a page-size-agnostic manner, and for object files to be re-linked with different Wasm page sizes, without needing to recompile the source.