### PR TITLE
memory_max.wast: make malformed test invalid for wasm-3.0/memory64

### DIFF
--- a/test/core/custom-page-sizes/memory_max.wast
+++ b/test/core/custom-page-sizes/memory_max.wast
@@ -23,14 +23,12 @@
   "unknown import")
 
 ;; Memory size just over the maximum.
-;;
-;; These are malformed (for pagesize 1)
-;; or invalid (for other pagesizes).
 
 ;; i32 (pagesize 1)
-(assert_malformed
-  (module quote "(memory 0x1_0000_0000 (pagesize 1))")
-  "constant out of range")
+(assert_invalid
+  (module
+    (memory 0x1_0000_0000 (pagesize 1)))
+  "memory size must be at most")
 
 ;; i32 (default pagesize)
 (assert_invalid


### PR DESCRIPTION
Adjust one of the memory_max tests from "malformed" to "invalid". In wasm-3.0 (post-memory64), this is no longer malformed (https://github.com/WebAssembly/spec/blob/wasm-3.0/test/core/memory.wast#L77).