### PR TITLE
Overview.md: update binary limits description

### DIFF
--- a/proposals/custom-page-sizes/Overview.md
+++ b/proposals/custom-page-sizes/Overview.md
@@ -159,22 +159,22 @@ The [`limits`][limits-binary] production is extended such that it returns a
 and memory64 proposals -- where the fourth value is the page size:
 
 ```ebnf
-limits ::= 0x00 n:u32              ⇒ i32, {min n, max ϵ}, unshared, 65536
-        |  0x01 n:u32 m:u32        ⇒ i32, {min n, max m}, unshared, 65536
-        |  0x02 n:u32              ⇒ i32, {min n, max ϵ},   shared, 65536
-        |  0x03 n:u32 m:u32        ⇒ i32, {min n, max m},   shared, 65536
+limits ::= 0x00 n:u64              ⇒ i32, {min n, max ϵ}, unshared, 65536
+        |  0x01 n:u64 m:u64        ⇒ i32, {min n, max m}, unshared, 65536
+        |  0x02 n:u64              ⇒ i32, {min n, max ϵ},   shared, 65536
+        |  0x03 n:u64 m:u64        ⇒ i32, {min n, max m},   shared, 65536
         |  0x04 n:u64              ⇒ i64, {min n, max ϵ}, unshared, 65536
         |  0x05 n:u64 m:u64        ⇒ i64, {min n, max m}, unshared, 65536
         |  0x06 n:u64              ⇒ i64, {min n, max ϵ},   shared, 65536
         |  0x07 n:u64 m:u64        ⇒ i64, {min n, max m},   shared, 65536
-        |  0x08 n:u32       p:u32  ⇒ i32, {min n, max ϵ}, unshared, 2**p  if p <= 16
-        |  0x09 n:u32 m:u32 p:u32  ⇒ i32, {min n, max m}, unshared, 2**p  if p <= 16
-        |  0x0a n:u32       p:u32  ⇒ i32, {min n, max ϵ},   shared, 2**p  if p <= 16
-        |  0x0b n:u32 m:u32 p:u32  ⇒ i32, {min n, max m},   shared, 2**p  if p <= 16
-        |  0x0c n:u64       p:u32  ⇒ i64, {min n, max ϵ}, unshared, 2**p  if p <= 16
-        |  0x0d n:u64 m:u64 p:u32  ⇒ i64, {min n, max m}, unshared, 2**p  if p <= 16
-        |  0x0e n:u64       p:u32  ⇒ i64, {min n, max ϵ},   shared, 2**p  if p <= 16
-        |  0x0f n:u64 m:u64 p:u32  ⇒ i64, {min n, max m},   shared, 2**p  if p <= 16
+        |  0x08 n:u64       p:u32  ⇒ i32, {min n, max ϵ}, unshared, 2**p  if p <= 64
+        |  0x09 n:u64 m:u64 p:u32  ⇒ i32, {min n, max m}, unshared, 2**p  if p <= 64
+        |  0x0a n:u64       p:u32  ⇒ i32, {min n, max ϵ},   shared, 2**p  if p <= 64
+        |  0x0b n:u64 m:u64 p:u32  ⇒ i32, {min n, max m},   shared, 2**p  if p <= 64
+        |  0x0c n:u64       p:u32  ⇒ i64, {min n, max ϵ}, unshared, 2**p  if p <= 64
+        |  0x0d n:u64 m:u64 p:u32  ⇒ i64, {min n, max m}, unshared, 2**p  if p <= 64
+        |  0x0e n:u64       p:u32  ⇒ i64, {min n, max ϵ},   shared, 2**p  if p <= 64
+        |  0x0f n:u64 m:u64 p:u32  ⇒ i64, {min n, max m},   shared, 2**p  if p <= 64
 ```
 
 [limits-binary]: https://webassembly.github.io/spec/core/binary/types.html#limits


### PR DESCRIPTION
In Overview.md, the binary-format `limits` BNF looks to have been adapted from the memory64 overview, but as integrated into the spec wasm-3.0 branch, the binary limits looks to have changed slightly and limits `min` and `max` are now always u64-typed. This PR updates the overview to match.

This also updates the binary limits production to reflect that page sizes $\le 2^{64}$ B are syntactically expressible.