### PR TITLE
Change an `assert_malformed` to `assert_invalid`

### DIFF
--- a/test/core/custom-page-sizes/custom-page-sizes-invalid.wast
+++ b/test/core/custom-page-sizes/custom-page-sizes-invalid.wast
@@ -79,7 +79,7 @@
 
 ;; Power of two page size that cannot fit in a u64 to exercise checks against
 ;; shift overflow.
-(assert_malformed
+(assert_invalid
   (module binary
     "\00asm" "\01\00\00\00"
     "\05\04\01"                ;; Memory section


### PR DESCRIPTION
Inspired by changes in https://github.com/bytecodealliance/wasm-tools/pull/2134 and intended to reflect how the maximum page size is an artifact of validation, not binary parsing.