### PR TITLE
Adjust unlinkable test in memory_max tests

### DIFF
--- a/test/core/custom-page-sizes/memory_max.wast
+++ b/test/core/custom-page-sizes/memory_max.wast
@@ -2,11 +2,17 @@
 ;;
 ;; These modules are valid, but instantiating them is unnecessary
 ;; and would only allocate very large memories and slow down running
-;; the spec tests. Therefore, add a missing import so that it cannot
+;; the spec tests. Therefore, add an invalid import so that it cannot
 ;; be instantiated and use `assert_unlinkable`. This approach
 ;; enforces that the module itself is still valid, but that its
 ;; instantiation fails early (hopefully before any memories are
 ;; actually allocated).
+
+;; Helper module that exports a non-matching value.
+(module
+  (memory (export "unknown") 0))
+
+(register "test")
 
 ;; i32 (pagesize 1)
 (assert_unlinkable

--- a/test/core/custom-page-sizes/memory_max_i64.wast
+++ b/test/core/custom-page-sizes/memory_max_i64.wast
@@ -2,11 +2,17 @@
 ;;
 ;; These modules are valid, but instantiating them is unnecessary
 ;; and would only allocate very large memories and slow down running
-;; the spec tests. Therefore, add a missing import so that it cannot
+;; the spec tests. Therefore, add an invalid import so that it cannot
 ;; be instantiated and use `assert_unlinkable`. This approach
 ;; enforces that the module itself is still valid, but that its
 ;; instantiation fails early (hopefully before any memories are
 ;; actually allocated).
+
+;; Helper module that exports a non-matching value.
+(module
+  (memory (export "unknown") 0))
+
+(register "test")
 
 ;; i64 (pagesize 1)
 (assert_unlinkable


### PR DESCRIPTION
When the import is missing, the first step in ["read the imports"](https://webassembly.github.io/spec/js-api/index.html#read-the-imports) in the JS API will cause a TypeError to be thrown when run in a browser implementation. But the test expects a link error instead due to using `assert_unlinkable`.

This PR changes the dummy import in the test so it's an invalid import with the wrong type, which should produce a link error as desired.