### PR TITLE
Implement parser support

### DIFF
--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -32,7 +32,7 @@ let valid_size at pt i =
 
 let create n (PageT ps) =
   try
-    let size = Int64.(shift_left n ps) in
+    let size = Int64.shift_left n ps in
     let mem = Array1_64.create Int8_unsigned C_layout size in
     Array1.fill mem 0;
     mem
@@ -48,7 +48,7 @@ let bound mem =
   Array1_64.dim mem.content
 
 let pagesize mem =
-  let MemoryT (_, _, PageT x) = mem.ty in (Int64.shift_left 1L x)
+  let MemoryT (_, _, PageT x) = mem.ty in Int64.shift_left 1L x
 
 let size mem =
   Int64.(div (bound mem) (pagesize mem))

--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -24,7 +24,7 @@ let valid_limits {min; max} =
 
 let valid_size at pt i =
   match pt with
-  | PageT 1 -> true
+  | PageT 0 -> true
   | PageT ps ->
      match at with
      | I32AT -> I64.le_u i (Int64.shift_right 0xffffffffL ps)

--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -27,7 +27,7 @@ let valid_size at pt i =
   | PageT 1 -> true
   | PageT ps ->
      match at with
-     | I32AT -> I64.le_u i (Int64.div 0xffffffffL (Int64.of_int ps))
+     | I32AT -> I64.le_u i (Int64.shift_right 0xffffffffL ps)
      | I64AT -> true
 
 let create n (PageT ps) =

--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -23,12 +23,9 @@ let valid_limits {min; max} =
   | Some m -> I64.le_u min m
 
 let valid_size at pt i =
-  match pt with
-  | PageT 0 -> true
-  | PageT ps ->
-     match at with
-     | I32AT -> I64.le_u i (Int64.shift_right 0xffffffffL ps)
-     | I64AT -> true
+  match at, pt with
+  | I32AT, PageT ps -> I64.le_u i (Int64.shift_right 0xffff_ffffL ps)
+  | _, _ -> true
 
 let create n (PageT ps) =
   try

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -780,6 +780,7 @@ rule token = parse
       | "start" -> START
       | "import" -> IMPORT
       | "export" -> EXPORT
+      | "pagesize" -> PAGESIZE
 
       | "module" -> MODULE
       | "binary" -> BIN

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -1153,7 +1153,7 @@ memory_fields :
       mems, data, ims, $1 (MemoryX x) c :: exs }
   | addrtype pagetype LPAR DATA string_list RPAR  /* Sugar */
     { fun c x loc ->
-      let len64 = (Int64.of_int (String.length $5)) in
+      let len64 = Int64.of_int (String.length $5) in
       let size =
         match $2 with
         | PageT 0 -> len64 (* will be a validation error *)

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -1149,18 +1149,16 @@ memory_fields :
       [Import (fst $1, snd $1, ExternMemoryT ($2 c)) @@ loc], [] }
   | inline_export memory_fields  /* Sugar */
     { fun c x loc -> let mems, data, ims, exs = $2 c x loc in
-      mems, data, ims, $1 (MemoryX x) c :: exs }
+		     mems, data, ims, $1 (MemoryX x) c :: exs }
   | addrtype pagetype LPAR DATA string_list RPAR  /* Sugar */
     { fun c x loc ->
       let len64 = Int64.of_int (String.length $5) in
       let size =
-        match $2 with
-        | PageT 0 -> len64
-	| PageT ps ->
-           let page_size = Int64.shift_left 1L ps in
-           let mask = Int64.sub page_size 1L in
-           let rounded = Int64.logand (Int64.add len64 mask) (Int64.lognot mask) in
-           Int64.shift_right rounded ps
+        let PageT ps = $2 in
+        let page_size = Int64.shift_left 1L ps in
+        let mask = Int64.sub page_size 1L in
+        let rounded = Int64.logand (Int64.add len64 mask) (Int64.lognot mask) in
+        Int64.shift_right rounded ps
       in
       let offset = [at_const $1 (0L @@ loc) @@ loc] @@ loc in
       [Memory (MemoryT ($1, {min = size; max = Some size}, $2)) @@ loc],

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -473,6 +473,7 @@ tabletype :
         error (at $sloc) "invalid custom page size: must be power of two";
       PageT (Int32.to_int (Lib.Int32.log2_unsigned n)) }
   | /* empty */ { PageT 16 }  /* Sugar */
+
 memorytype :
   | addrtype limits pagetype { fun c -> MemoryT ($1, $2, $3) }
 
@@ -1133,7 +1134,7 @@ memory_fields :
       [Import (fst $1, snd $1, ExternMemoryT ($2 c)) @@ loc], [] }
   | inline_export memory_fields  /* Sugar */
     { fun c x loc -> let mems, data, ims, exs = $2 c x loc in
-		     mems, data, ims, $1 (MemoryX x) c :: exs }
+      mems, data, ims, $1 (MemoryX x) c :: exs }
   | addrtype pagetype LPAR DATA string_list RPAR  /* Sugar */
     { fun c x loc ->
       let PageT ps = $2 in
@@ -1143,6 +1144,7 @@ memory_fields :
       [Memory (MemoryT ($1, {min = size; max = Some size}, $2)) @@ loc],
       [Data ($5, Active (x, offset) @@ loc) @@ loc],
       [], [] }
+
 
 elemkind :
   | FUNC { (NoNull, FuncHT) }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -466,15 +466,14 @@ subtype :
 tabletype :
   | addrtype limits reftype { fun c -> TableT ($1, $2, $3 c) }
 
-pagetype :
+%inline pagetype :
   | LPAR PAGESIZE NAT RPAR
     { let n = (nat32 $3 $loc($3)) in
       if not (Lib.Int32.is_power_of_two_unsigned n) then
         error (at $sloc) "invalid custom page size: must be power of two";
       PageT (Int32.to_int (Lib.Int32.log2_unsigned n)) }
-
+  | /* empty */ { PageT 16 }  /* Sugar */
 memorytype :
-  | addrtype limits { fun c -> MemoryT ($1, $2, PageT 16) }
   | addrtype limits pagetype { fun c -> MemoryT ($1, $2, $3) }
 
 limits :
@@ -1135,14 +1134,6 @@ memory_fields :
   | inline_export memory_fields  /* Sugar */
     { fun c x loc -> let mems, data, ims, exs = $2 c x loc in
 		     mems, data, ims, $1 (MemoryX x) c :: exs }
-  | addrtype LPAR DATA string_list RPAR  /* Sugar */
-    { fun c x loc ->
-      let page_size = 65536L in
-      let size = Int64.(div (add (of_int (String.length $4)) (sub page_size 1L)) page_size) in
-      let offset = [at_const $1 (0L @@ loc) @@ loc] @@ loc in
-      [Memory (MemoryT ($1, {min = size; max = Some size}, (PageT 16))) @@ loc],
-      [Data ($4, Active (x, offset) @@ loc) @@ loc],
-      [], [] }
   | addrtype pagetype LPAR DATA string_list RPAR  /* Sugar */
     { fun c x loc ->
       let PageT ps = $2 in

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -1135,6 +1135,14 @@ memory_fields :
   | inline_export memory_fields  /* Sugar */
     { fun c x loc -> let mems, data, ims, exs = $2 c x loc in
 		     mems, data, ims, $1 (MemoryX x) c :: exs }
+  | addrtype LPAR DATA string_list RPAR  /* Sugar */
+    { fun c x loc ->
+      let page_size = 65536L in
+      let size = Int64.(div (add (of_int (String.length $4)) (sub page_size 1L)) page_size) in
+      let offset = [at_const $1 (0L @@ loc) @@ loc] @@ loc in
+      [Memory (MemoryT ($1, {min = size; max = Some size}, (PageT 16))) @@ loc],
+      [Data ($4, Active (x, offset) @@ loc) @@ loc],
+      [], [] }
   | addrtype pagetype LPAR DATA string_list RPAR  /* Sugar */
     { fun c x loc ->
       let PageT ps = $2 in

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -313,8 +313,16 @@ struct
       if n = 1l then acc else loop (Int32.add acc 1l) (Int32.shift_right_logical n 1) in
     loop 0l n
 
+  let log2_unsigned n =
+    let rec loop acc n =
+      if n = 1l then acc else loop (Int32.add acc 1l) (Int32.shift_right_logical n 1) in
+    loop 0l n
+  
   let is_power_of_two n =
     if n < 0l then failwith "is_power_of_two";
+    n <> 0l && Int32.(logand n (sub n 1l)) = 0l
+
+  let is_power_of_two_unsigned n =
     n <> 0l && Int32.(logand n (sub n 1l)) = 0l
 end
 

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -315,12 +315,12 @@ struct
   let log2 n =
     if n <= 0l then failwith "log2" else log2_unsigned n
   
-  let is_power_of_two n =
-    if n < 0l then failwith "is_power_of_two";
-    n <> 0l && Int32.(logand n (sub n 1l)) = 0l
-
   let is_power_of_two_unsigned n =
     n <> 0l && Int32.(logand n (sub n 1l)) = 0l
+
+  let is_power_of_two n =
+    if n < 0l then failwith "is_power_of_two" else
+    is_power_of_two_unsigned n
 end
 
 module Int64 =

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -307,16 +307,13 @@ end
 
 module Int32 =
 struct
-  let log2 n =
-    if n <= 0l then failwith "log2";
-    let rec loop acc n =
-      if n = 1l then acc else loop (Int32.add acc 1l) (Int32.shift_right_logical n 1) in
-    loop 0l n
-
   let log2_unsigned n =
     let rec loop acc n =
       if n = 1l then acc else loop (Int32.add acc 1l) (Int32.shift_right_logical n 1) in
     loop 0l n
+  
+  let log2 n =
+    if n <= 0l then failwith "log2" else log2_unsigned n
   
   let is_power_of_two n =
     if n < 0l then failwith "is_power_of_two";

--- a/interpreter/util/lib.mli
+++ b/interpreter/util/lib.mli
@@ -97,7 +97,9 @@ end
 module Int32 :
 sig
   val log2 : int32 -> int32
+  val log2_unsigned : int32 -> int32
   val is_power_of_two : int32 -> bool
+  val is_power_of_two_unsigned : int32 -> bool
 end
 
 module Int64 :

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -203,7 +203,7 @@ let check_memorytype (c : context) (mt : memorytype) at =
   check_pagetype pt at;
   let sz, s =
     match pt with
-    | PageT 0x10000 ->
+    | PageT 16 ->
        (match at_ with
        | I32AT -> 0x1_0000L, "2^16 pages (4 GiB) for i32"
        | I64AT -> 0x1_0000_0000_0000L, "2^48 pages (256 TiB) for i64")

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -200,6 +200,7 @@ let check_globaltype (c : context) (gt : globaltype) at =
 
 let check_memorytype (c : context) (mt : memorytype) at =
   let MemoryT (at_, lim, pt) = mt in
+  check_pagetype pt at;
   let sz, s =
     match pt with
     | PageT 0x10000 ->
@@ -211,8 +212,7 @@ let check_memorytype (c : context) (mt : memorytype) at =
        | I32AT -> 0xFFFF_FFFFL, "2^32 - 1 bytes for i32"
        | I64AT -> 0xFFFF_FFFF_FFFF_FFFFL, "2^64 - 1 bytes for i64")
   in
-  check_limits lim sz at ("memory size must be at most " ^ s);
-  check_pagetype pt at
+  check_limits lim sz at ("memory size must be at most " ^ s)
 
 let check_tabletype (c : context) (tt : tabletype) at =
   let TableT (at_, lim, t) = tt in

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -204,7 +204,7 @@ let check_memorytype (c : context) (mt : memorytype) at =
   let sz, s =
     match at_, pt with
     | I32AT, PageT 16 -> 0x1_0000L, "2^16 pages (4 GiB) for i32"
-    | I64AT, PageT 16 -> 0x1_0000_0000_0000L, "2^48 pages (256 TiB) for i64")
+    | I64AT, PageT 16 -> 0x1_0000_0000_0000L, "2^48 pages (256 TiB) for i64"
     (* TODO: divide by page size, what about error msg? *)
     | I32AT, _ -> 0xFFFF_FFFFL, "2^32 - 1 bytes for i32"
     | I64AT, _ -> 0xFFFF_FFFF_FFFF_FFFFL, "2^64 - 1 bytes for i64"

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -202,15 +202,12 @@ let check_memorytype (c : context) (mt : memorytype) at =
   let MemoryT (at_, lim, pt) = mt in
   check_pagetype pt at;
   let sz, s =
-    match pt with
-    | PageT 16 ->
-       (match at_ with
-       | I32AT -> 0x1_0000L, "2^16 pages (4 GiB) for i32"
-       | I64AT -> 0x1_0000_0000_0000L, "2^48 pages (256 TiB) for i64")
-    | _ -> (* TODO: divide by page size, what about error msg? *)
-       (match at_ with
-       | I32AT -> 0xFFFF_FFFFL, "2^32 - 1 bytes for i32"
-       | I64AT -> 0xFFFF_FFFF_FFFF_FFFFL, "2^64 - 1 bytes for i64")
+    match at_, pt with
+    | I32AT, PageT 16 -> 0x1_0000L, "2^16 pages (4 GiB) for i32"
+    | I64AT, PageT 16 -> 0x1_0000_0000_0000L, "2^48 pages (256 TiB) for i64")
+    (* TODO: divide by page size, what about error msg? *)
+    | I32AT, _ -> 0xFFFF_FFFFL, "2^32 - 1 bytes for i32"
+    | I64AT, _ -> 0xFFFF_FFFF_FFFF_FFFFL, "2^64 - 1 bytes for i64"
   in
   check_limits lim sz at ("memory size must be at most " ^ s)
 

--- a/test/core/custom-page-sizes/custom-page-sizes.wast
+++ b/test/core/custom-page-sizes/custom-page-sizes.wast
@@ -110,7 +110,7 @@
 ;; Inline data segments
 
 ;; pagesize 0
-(assert_malformed (module quote "(memory (pagesize 0) (data))") "invalid custom page size")
+(assert_malformed (module quote "(module (memory (pagesize 0) (data)))") "invalid custom page size")
 
 ;; pagesize 1
 (module

--- a/test/core/custom-page-sizes/memory_max.wast
+++ b/test/core/custom-page-sizes/memory_max.wast
@@ -19,14 +19,26 @@
   (module
     (import "test" "unknown" (func))
     (memory 0xFFFF_FFFF (pagesize 1)))
-  "unknown import")
+  "incompatible import type")
+
+;; i32 (pagesize 1)
+(assert_unlinkable
+  (module
+    (import "test" "unknown" (memory 0xFFFF_FFFF (pagesize 1))))
+  "incompatible import type")
 
 ;; i32 (default pagesize)
 (assert_unlinkable
   (module
     (import "test" "unknown" (func))
     (memory 65536 (pagesize 65536)))
-  "unknown import")
+  "incompatible import type")
+
+;; i32 (default pagesize)
+(assert_unlinkable
+  (module
+    (import "test" "unknown" (memory 65536 (pagesize 65536))))
+  "incompatible import type")
 
 ;; Memory size just over the maximum.
 

--- a/test/core/custom-page-sizes/memory_max_i64.wast
+++ b/test/core/custom-page-sizes/memory_max_i64.wast
@@ -17,16 +17,28 @@
 ;; i64 (pagesize 1)
 (assert_unlinkable
   (module
-    (import "test" "import" (func))
+    (import "test" "unknown" (func))
     (memory i64 0xFFFF_FFFF_FFFF_FFFF (pagesize 1)))
-  "unknown import")
+  "incompatible import type")
+
+;; i64 (pagesize 1)
+(assert_unlinkable
+  (module
+    (import "test" "unknown" (memory i64 0xFFFF_FFFF_FFFF_FFFF (pagesize 1))))
+  "incompatible import type")
 
 ;; i64 (default pagesize)
 (assert_unlinkable
   (module
     (import "test" "unknown" (func))
     (memory i64 0x1_0000_0000_0000 (pagesize 65536)))
-  "unknown import")
+  "incompatible import type")
+
+;; i64 (default pagesize)
+(assert_unlinkable
+  (module
+    (import "test" "unknown" (memory i64 0x1_0000_0000_0000 (pagesize 65536))))
+  "incompatible import type")
 
 ;; Memory size just over the maximum.
 ;;
@@ -36,7 +48,7 @@
 ;; i64 (pagesize 1)
 (assert_malformed
   (module quote "(memory i64 0x1_0000_0000_0000_0000 (pagesize 1))")
-  "constant out of range")
+  "i64 constant out of range")
 
 ;; i64 (default pagesize)
 (assert_invalid


### PR DESCRIPTION
This implements parser support and (I think) the intended semantics that custom page sizes that are `0` or not powers of two are malformed, and powers of two that are not 1 or 65536 are invalid.

@rossberg PTAL. There is a shift/reduce conflict here due to the factoring of the pagetype/memorytype having to do with the syntactic sugar for data segments. I think it requires left-factoring the grammar and rearranging it a little; I wasn't sure if you a convention you were following for how that's done.

